### PR TITLE
Avoid target directories within the source directory getting stuck.

### DIFF
--- a/Filesystem.php
+++ b/Filesystem.php
@@ -569,6 +569,10 @@ class Filesystem
         }
 
         foreach ($iterator as $file) {
+            if ($file->getPathName() === $targetDir) {
+                continue;
+            }
+
             if (false === strpos($file->getPath(), $originDir)) {
                 throw new IOException(sprintf('Unable to mirror "%s" directory. If the origin directory is relative, try using "realpath" before calling the mirror method.', $originDir), 0, null, $originDir);
             }

--- a/Tests/FilesystemTest.php
+++ b/Tests/FilesystemTest.php
@@ -1178,7 +1178,7 @@ class FilesystemTest extends FilesystemTestCase
         file_put_contents($file1, 'FILE1');
         file_put_contents($file2, 'FILE2');
 
-        $targetPath = $sourcePath . 'target' . \DIRECTORY_SEPARATOR;
+        $targetPath = $this->workspace.\DIRECTORY_SEPARATOR.'target'.\DIRECTORY_SEPARATOR;
 
         $this->filesystem->mirror($sourcePath, $targetPath);
 
@@ -1188,7 +1188,6 @@ class FilesystemTest extends FilesystemTestCase
         $this->assertFileEquals($file2, $targetPath.'file2');
 
         $this->filesystem->remove($file1);
-
         $this->filesystem->mirror($sourcePath, $targetPath, null, array('delete' => false));
         $this->assertTrue($this->filesystem->exists($targetPath.'directory'.\DIRECTORY_SEPARATOR.'file1'));
 
@@ -1370,6 +1369,31 @@ class FilesystemTest extends FilesystemTestCase
         $iterator = new \ArrayObject(array($splFile));
 
         $this->filesystem->mirror($sourcePath, $targetPath, $iterator);
+    }
+
+    public function testMirrorAvoidCopyingTargetDirectoryIfInSourceDirectory()
+    {
+        $sourcePath = $this->workspace.\DIRECTORY_SEPARATOR.'source'.\DIRECTORY_SEPARATOR;
+        $directory = $sourcePath.'directory'.\DIRECTORY_SEPARATOR;
+        $file1 = $directory.'file1';
+        $file2 = $sourcePath.'file2';
+
+        mkdir($sourcePath);
+        mkdir($directory);
+        file_put_contents($file1, 'FILE1');
+        file_put_contents($file2, 'FILE2');
+
+        $targetPath = $sourcePath . 'target' . \DIRECTORY_SEPARATOR;
+
+        $this->filesystem->mirror($sourcePath, $targetPath);
+
+        $this->assertTrue(is_dir($targetPath));
+        $this->assertTrue(is_dir($targetPath.'directory'));
+
+        $this->assertFileEquals($file1, $targetPath.'directory'.\DIRECTORY_SEPARATOR.'file1');
+        $this->assertFileEquals($file2, $targetPath.'file2');
+
+        $this->assertFalse(file_exists($targetPath.'target'));
     }
 
     /**

--- a/Tests/FilesystemTest.php
+++ b/Tests/FilesystemTest.php
@@ -1178,7 +1178,7 @@ class FilesystemTest extends FilesystemTestCase
         file_put_contents($file1, 'FILE1');
         file_put_contents($file2, 'FILE2');
 
-        $targetPath = $this->workspace.\DIRECTORY_SEPARATOR.'target'.\DIRECTORY_SEPARATOR;
+        $targetPath = $sourcePath . 'target' . \DIRECTORY_SEPARATOR;
 
         $this->filesystem->mirror($sourcePath, $targetPath);
 


### PR DESCRIPTION
Currently when you run:
```php
$filesystem->mirror('/foo', '/foo/bar');
```
The method will get caught in a recursive loop of creating "bar" sub directories in the target directory.

This will happen:
```
/foo/bar/bar/
/foo/bar/bar/bar/
/foo/bar/bar/bar/bar/
...
```
Until the path is so long that is validated as an invalid path string and thus mkdir() crashes.

In this pull request I implemented an if statement at the beginning of the foreach in the mirror() method. This if statement ensures that the target directory in the mirror process is skipped.